### PR TITLE
Add 'View surrounding pages' link to row detail pages

### DIFF
--- a/templates/datasette/row-meetings-agendas.html
+++ b/templates/datasette/row-meetings-agendas.html
@@ -1,0 +1,37 @@
+{% extends "default:row.html" %}
+
+{% block content %}
+<h1 style="padding-left: 10px; border-left: 10px solid #{{ database_color }}">
+    {{ table }}: {{ ', '.join(primary_key_values) }}{% if private %} 🔒{% endif %}
+</h1>
+
+{% if rows and rows[0].page %}
+<p style="margin: 0.5rem 0;">
+    <a href="/{{ database }}/{{ table }}?meeting__exact={{ rows[0].meeting|urlencode }}&date__exact={{ rows[0].date|urlencode }}&page__gte={{ [rows[0].page - 2, 1]|max }}&page__lte={{ rows[0].page + 2 }}&_sort=page">View surrounding pages (pages {{ [rows[0].page - 2, 1]|max }}–{{ rows[0].page + 2 }})</a>
+</p>
+{% endif %}
+
+{% set action_links, action_title = row_actions, "Row actions" %}
+{% include "_action_menu.html" %}
+
+{{ top_row() }}
+
+{% block description_source_license %}{% include "_description_source_license.html" %}{% endblock %}
+
+<p>This data as {% for name, url in renderers.items() %}<a href="{{ url }}">{{ name }}</a>{{ ", " if not loop.last }}{% endfor %}</p>
+
+{% include custom_table_templates %}
+
+{% if foreign_key_tables %}
+    <h2>Links from other tables</h2>
+    <ul>
+        {% for other in foreign_key_tables %}
+            <li>
+                <a href="{{ other.link }}">
+                    {{ "{:,}".format(other.count) }} row{% if other.count == 1 %}{% else %}s{% endif %}</a>
+                from {{ other.other_column }} in {{ other.other_table }}
+            </li>
+        {% endfor %}
+    </ul>
+{% endif %}
+{% endblock %}

--- a/templates/datasette/row-meetings-minutes.html
+++ b/templates/datasette/row-meetings-minutes.html
@@ -1,0 +1,37 @@
+{% extends "default:row.html" %}
+
+{% block content %}
+<h1 style="padding-left: 10px; border-left: 10px solid #{{ database_color }}">
+    {{ table }}: {{ ', '.join(primary_key_values) }}{% if private %} 🔒{% endif %}
+</h1>
+
+{% if rows and rows[0].page %}
+<p style="margin: 0.5rem 0;">
+    <a href="/{{ database }}/{{ table }}?meeting__exact={{ rows[0].meeting|urlencode }}&date__exact={{ rows[0].date|urlencode }}&page__gte={{ [rows[0].page - 2, 1]|max }}&page__lte={{ rows[0].page + 2 }}&_sort=page">View surrounding pages (pages {{ [rows[0].page - 2, 1]|max }}–{{ rows[0].page + 2 }})</a>
+</p>
+{% endif %}
+
+{% set action_links, action_title = row_actions, "Row actions" %}
+{% include "_action_menu.html" %}
+
+{{ top_row() }}
+
+{% block description_source_license %}{% include "_description_source_license.html" %}{% endblock %}
+
+<p>This data as {% for name, url in renderers.items() %}<a href="{{ url }}">{{ name }}</a>{{ ", " if not loop.last }}{% endfor %}</p>
+
+{% include custom_table_templates %}
+
+{% if foreign_key_tables %}
+    <h2>Links from other tables</h2>
+    <ul>
+        {% for other in foreign_key_tables %}
+            <li>
+                <a href="{{ other.link }}">
+                    {{ "{:,}".format(other.count) }} row{% if other.count == 1 %}{% else %}s{% endif %}</a>
+                from {{ other.other_column }} in {{ other.other_table }}
+            </li>
+        {% endfor %}
+    </ul>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- Adds a "View surrounding pages" link to agendas and minutes row detail pages
- Link shows 2 pages before and 2 after the current page for context
- Minimal styling that blends with existing Datasette interface

## Implementation
Created two custom Datasette row templates:
- `templates/datasette/row-meetings-agendas.html`
- `templates/datasette/row-meetings-minutes.html`

Both templates extend the default Datasette `row.html` template and add a context link near the top of the page.

## Example
For a row at page 5 of a meeting:
- Link text: "View surrounding pages (pages 3–7)"
- Target URL: `/meetings/agendas?meeting__exact=CityCouncil&date__exact=2024-01-02&page__gte=3&page__lte=7&_sort=page`

## Test Plan
- [ ] Start Datasette instance
- [ ] Navigate to any agendas row detail page (e.g., `/meetings/agendas/{id}`)
- [ ] Verify "View surrounding pages" link appears near the top
- [ ] Click link and verify it shows filtered table with context pages
- [ ] Repeat for minutes table
- [ ] Test edge cases (page 1, page 2) to ensure no negative page numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)