### PR TITLE
Fix Logfire init: move to ASGI after Django is initialized

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -228,18 +228,4 @@ API_KEY_VALID_TTL = 7200  # 2 hours for valid keys
 API_KEY_INVALID_TTL = 300  # 5 minutes for invalid keys
 
 
-# Logfire configuration for tracing and structured logging
-import logfire
-
-if DEBUG:
-    # Development: console output only, no data sent to Logfire
-    logfire.configure(send_to_logfire=False)
-else:
-    # Production: full telemetry if token is configured
-    logfire_token = os.environ.get("LOGFIRE_TOKEN")
-    if logfire_token:
-        logfire.configure(token=logfire_token)
-        logfire.instrument_django()
-
-
 djp.settings(globals())


### PR DESCRIPTION
## Summary

Fixes deploy error: `AttributeError: 'Settings' object has no attribute 'ROOT_URLCONF'`

`logfire.instrument_django()` requires Django to be fully configured, but it was being called during settings module import when `ROOT_URLCONF` wasn't available yet.

## Changes

- Move Logfire configuration from `config/settings.py` to `config/asgi.py`
- Configure Logfire after `get_asgi_application()` has been called, ensuring Django is fully initialized

## Test plan

- [x] All 138 tests pass locally
- [ ] Deploy and verify no `ROOT_URLCONF` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)