### PR TITLE
Suppress rich debug output for 404 errors

### DIFF
--- a/plugins/exception_handler.py
+++ b/plugins/exception_handler.py
@@ -1,0 +1,41 @@
+"""Custom exception handler to suppress noisy rich output for 404s.
+
+When rich is installed (e.g., via logfire), Datasette's default exception
+handler prints full tracebacks to the console for ALL exceptions, including
+routine 404s from bot scanners. This creates excessive noise in logs.
+
+This plugin intercepts NotFound exceptions and returns a clean 404 response
+without the rich debug output, while letting actual errors (500s) through
+to be properly logged.
+"""
+
+from datasette import Response, hookimpl
+from datasette.utils.asgi import NotFound
+
+
+@hookimpl
+def handle_exception(datasette, request, exception):
+    """Handle exceptions, suppressing rich output for 404s."""
+    # Only intercept NotFound (404) exceptions
+    if isinstance(exception, NotFound):
+
+        async def inner():
+            # Return a simple 404 response
+            return Response.html(
+                await datasette.render_template(
+                    "404.html",
+                    {
+                        "error": "Page not found",
+                        "status": 404,
+                        "title": "Page not found",
+                    },
+                    request=request,
+                ),
+                status=404,
+            )
+
+        return inner
+
+    # Let other exceptions (500s, etc.) fall through to default handler
+    # which will log them properly via Sentry
+    return None


### PR DESCRIPTION
## Summary

Fixes noisy error logging from bot scanners hitting non-existent paths like `/wp-content/plugins/pwnd/as.php`.

When `rich` is installed (via `logfire`), Datasette's default exception handler calls `rich.get_console().print_exception(show_locals=True)` for **all** exceptions - including routine 404s. This creates excessive noise in logs and Bugsink.

## Changes

Added `plugins/exception_handler.py` with a `handle_exception` hook that:
- Intercepts `NotFound` (404) exceptions specifically  
- Returns a clean 404 response without the rich debug output
- Lets actual errors (500s, etc.) fall through to be properly logged by Sentry

## Test plan

- [x] All 138 tests pass
- [ ] Deploy and verify 404s no longer create Bugsink errors
- [ ] Verify actual 500 errors still get reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)