### PR TITLE
Add 404.html template for Datasette

### DIFF
--- a/templates/datasette/404.html
+++ b/templates/datasette/404.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block title %}Page not found - {{ site_name }}{% endblock %}
+
+{% block content %}
+<div class="error-page">
+    <h1>Page not found</h1>
+    <p>The page you're looking for doesn't exist.</p>
+    <p><a href="/">Return to homepage</a></p>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary

Adds the missing `404.html` template required by the custom exception handler from PR #24.

## Test plan

- [ ] Deploy and verify 404 pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)