### PR TITLE
fix: clip button column detection and color contrast

### DIFF
--- a/plugins/clip_to_notebook.py
+++ b/plugins/clip_to_notebook.py
@@ -6,9 +6,9 @@ from datasette import hookimpl
 
 @hookimpl
 def render_cell(row, value, column, table, database, datasette, request):
-    """Add a clip icon next to the rowid column for agendas/minutes tables."""
-    # Only process the rowid column
-    if column != "rowid":
+    """Add a clip icon next to the id column for agendas/minutes tables."""
+    # Only process the id column (primary key for these tables)
+    if column != "id":
         return None
 
     # Only for agendas and minutes tables

--- a/templates/datasette/row-meetings-agendas.html
+++ b/templates/datasette/row-meetings-agendas.html
@@ -120,10 +120,12 @@ document.querySelector('#citation-agendas-{{ primary_key_values[0] }} .access-da
     background: #0056b3;
 }
 
-.clip-button {
+a.clip-button,
+a.clip-button:link,
+a.clip-button:visited {
     display: inline-block;
     background: #28a745;
-    color: white;
+    color: white !important;
     text-decoration: none;
     border-radius: 4px;
     padding: 0.5rem 1rem;
@@ -131,9 +133,10 @@ document.querySelector('#citation-agendas-{{ primary_key_values[0] }} .access-da
     margin: 0.5rem 0;
 }
 
-.clip-button:hover {
+a.clip-button:hover,
+a.clip-button:active {
     background: #218838;
-    color: white;
+    color: white !important;
 }
 </style>
 {% endblock %}

--- a/templates/datasette/row-meetings-minutes.html
+++ b/templates/datasette/row-meetings-minutes.html
@@ -120,10 +120,12 @@ document.querySelector('#citation-minutes-{{ primary_key_values[0] }} .access-da
     background: #0056b3;
 }
 
-.clip-button {
+a.clip-button,
+a.clip-button:link,
+a.clip-button:visited {
     display: inline-block;
     background: #28a745;
-    color: white;
+    color: white !important;
     text-decoration: none;
     border-radius: 4px;
     padding: 0.5rem 1rem;
@@ -131,9 +133,10 @@ document.querySelector('#citation-minutes-{{ primary_key_values[0] }} .access-da
     margin: 0.5rem 0;
 }
 
-.clip-button:hover {
+a.clip-button:hover,
+a.clip-button:active {
     background: #218838;
-    color: white;
+    color: white !important;
 }
 </style>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Fix clip icon not appearing on table rows: changed column detection from `rowid` to `id` (the actual primary key column)
- Fix button color contrast: added `!important` and targeted all link pseudo-states (`:link`, `:visited`, `:hover`, `:active`) to override Datasette's default link styles

## Test plan
- [ ] Visit https://alameda.ca.civic.band/meetings/minutes and verify 📋 icons appear next to each row ID
- [ ] Visit a row detail page and verify the "Clip to Notebook" button has white text on green background (not Datasette's default link color)

🤖 Generated with [Claude Code](https://claude.com/claude-code)