### PR TITLE
fix: resolve template errors in clip button

### DIFF
--- a/plugins/clip_to_notebook.py
+++ b/plugins/clip_to_notebook.py
@@ -16,7 +16,8 @@ def render_cell(row, value, column, table, database, datasette, request):
         return None
 
     # Get the subdomain from plugin config
-    subdomain = datasette.plugin_config("corkboard", {}).get("subdomain", "")
+    config = datasette.plugin_config("corkboard") or {}
+    subdomain = config.get("subdomain", "")
 
     # Build the clip URL with UTM tracking
     clip_url = (

--- a/templates/datasette/row-meetings-agendas.html
+++ b/templates/datasette/row-meetings-agendas.html
@@ -18,7 +18,7 @@
     {{ table }}: {{ ', '.join(primary_key_values) }}{% if private %} 🔒{% endif %}
 </h1>
 
-<a href="https://civic.observer/clip/?id={{ primary_key_values[0] }}&subdomain={{ subdomain }}&table={{ table }}&utm_source=civicband&utm_medium=clip&utm_campaign={{ subdomain }}&utm_content=detail_button"
+<a href="https://civic.observer/clip/?id={{ rows[0].id }}&subdomain={{ subdomain }}&table={{ table }}&utm_source=civicband&utm_medium=clip&utm_campaign={{ subdomain }}&utm_content=detail_button"
    class="clip-button"
    target="_blank"
    data-umami-event="clip_to_notebook"

--- a/templates/datasette/row-meetings-minutes.html
+++ b/templates/datasette/row-meetings-minutes.html
@@ -18,7 +18,7 @@
     {{ table }}: {{ ', '.join(primary_key_values) }}{% if private %} 🔒{% endif %}
 </h1>
 
-<a href="https://civic.observer/clip/?id={{ primary_key_values[0] }}&subdomain={{ subdomain }}&table={{ table }}&utm_source=civicband&utm_medium=clip&utm_campaign={{ subdomain }}&utm_content=detail_button"
+<a href="https://civic.observer/clip/?id={{ rows[0].id }}&subdomain={{ subdomain }}&table={{ table }}&utm_source=civicband&utm_medium=clip&utm_campaign={{ subdomain }}&utm_content=detail_button"
    class="clip-button"
    target="_blank"
    data-umami-event="clip_to_notebook"


### PR DESCRIPTION
## Summary
- Use `rows[0].id` instead of `primary_key_values[0]` in templates to avoid "unhashable type: dict" error on detail pages
- Fix `plugin_config()` call to handle `None` return value properly

## Test plan
- [ ] Visit a row detail page (e.g., https://alameda.ca.civic.band/meetings/minutes/...) - should not show "unhashable type: dict" error
- [ ] Verify the "Clip to Notebook" button appears and links correctly
- [ ] Verify clip icons appear next to row IDs in table listings

🤖 Generated with [Claude Code](https://claude.com/claude-code)