### PR TITLE
feat: integrate datasette-updated plugin for footer timestamps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "datasette-dashboards>=0.1.0",
     "logfire[django,httpx,sqlite3]>=0.30.0",
     "datasette-search-all==1.1.4", # 1.1.5a0 requires datasette>=1.0a20
+    "datasette-updated>=0.2.0",
     "djp>=0.0.6",
     "jinja2>=3.0.0",
     "sqlite-utils>=3.30.0",

--- a/templates/config/metadata.json
+++ b/templates/config/metadata.json
@@ -10,6 +10,10 @@
       "site_name": "{{ context.name }}",
       "site_description_html": "A fully-searchable database of {{ context.name }}, {{ context.state }} civic meeting minutes and agendas. Last processed: {{ context.last_updated }}. See the full list at <a href=\"https://civic.band\">Civic Band</a>."
     },
+    "datasette-updated": {
+      "updated": "{{ context.last_updated }}",
+      "time_type": "date"
+    },
     "datasette-dashboards": {
       "meetings-stats": {
         "title": "{{ context.name }} Meeting Statistics",

--- a/templates/datasette/_footer.html
+++ b/templates/datasette/_footer.html
@@ -1,0 +1,29 @@
+Powered by <a href="https://datasette.io/" title="Datasette v{{ datasette_version }}">Datasette</a>
+{% if query_ms %}&middot; Queries took {{ query_ms|round(3) }}ms{% endif %}
+{% if metadata %}
+    {% if metadata.license or metadata.license_url %}&middot; Data license:
+        {% if metadata.license_url %}
+            <a href="{{ metadata.license_url }}">{{ metadata.license or metadata.license_url }}</a>
+        {% else %}
+            {{ metadata.license }}
+        {% endif %}
+    {% endif %}
+    {% if metadata.source or metadata.source_url %}&middot;
+        Data source: {% if metadata.source_url %}
+            <a href="{{ metadata.source_url }}">
+        {% endif %}{{ metadata.source or metadata.source_url }}{% if metadata.source_url %}</a>{% endif %}
+    {% endif %}
+    {% if metadata.about or metadata.about_url %}&middot;
+        About: {% if metadata.about_url %}
+            <a href="{{ metadata.about_url }}">
+        {% endif %}{{ metadata.about or metadata.about_url }}{% if metadata.about_url %}</a>{% endif %}
+    {% endif %}
+    {% if datasette_updated %}&middot;
+        Updated:
+        <time
+          data-local="{{ datasette_updated.time_type }}"
+          datetime="{{ datasette_updated.updated }}">
+            {{ datasette_updated.updated }}
+        </time>
+    {% endif %}
+{% endif %}

--- a/uv.lock
+++ b/uv.lock
@@ -210,6 +210,7 @@ dependencies = [
     { name = "datasette-dashboards" },
     { name = "datasette-search-all" },
     { name = "datasette-template-sql" },
+    { name = "datasette-updated" },
     { name = "django" },
     { name = "djp" },
     { name = "httpx" },
@@ -251,6 +252,7 @@ requires-dist = [
     { name = "datasette-dashboards", specifier = ">=0.1.0" },
     { name = "datasette-search-all", specifier = "==1.1.4" },
     { name = "datasette-template-sql", specifier = ">=1.0.2" },
+    { name = "datasette-updated", specifier = ">=0.2.0" },
     { name = "django", specifier = ">=4.2.0" },
     { name = "djp", specifier = ">=0.0.6" },
     { name = "fakeredis", marker = "extra == 'dev'", specifier = ">=2.20.0" },
@@ -425,6 +427,28 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/02/6022d05e4ba267c60b6e775ac80d445f3ea4b0509ce14208ca84166f9c58/datasette-template-sql-1.0.2.tar.gz", hash = "sha256:664c795c319e820be635803198b505dc01621324a8b4627b269e4c174563e8c3", size = 3084, upload-time = "2021-01-29T02:30:52.816Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/70/3a/80703eb171f8294dbf77c5777b0fa644370e9c5b53cd8f9e5722cf4cacfb/datasette_template_sql-1.0.2-py3-none-any.whl", hash = "sha256:194514201e8ce3489040e89a7887d8144bf27fd32580649a904be31de2cd0752", size = 7360, upload-time = "2021-01-29T02:30:51.873Z" },
+]
+
+[[package]]
+name = "datasette-updated"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "datasette" },
+    { name = "deepmerge" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/6a/2bc3e60d2e9077d4838fee8e84f1121f66f76a30aadda3cb45beecb8c3ed/datasette-updated-0.2.0.tar.gz", hash = "sha256:80792d04fa453733365a2f7a67c5115d5c888912fbe9a179b98be4e8d9acb678", size = 9047, upload-time = "2024-04-09T14:38:25.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/55/b4203969261cac5a23128342737e6b1a9504e31ab0e3f070637840b5c95b/datasette_updated-0.2.0-py3-none-any.whl", hash = "sha256:66837418c82eaf92d0c9f951760adaa09ea1dd2b84b8021337d5b776d426f1ad", size = 8900, upload-time = "2024-04-09T14:38:24.387Z" },
+]
+
+[[package]]
+name = "deepmerge"
+version = "2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/3a/b0ba594708f1ad0bc735884b3ad854d3ca3bdc1d741e56e40bbda6263499/deepmerge-2.0.tar.gz", hash = "sha256:5c3d86081fbebd04dd5de03626a0607b809a98fb6ccba5770b62466fe940ff20", size = 19890, upload-time = "2024-08-30T05:31:50.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/82/e5d2c1c67d19841e9edc74954c827444ae826978499bde3dfc1d007c8c11/deepmerge-2.0-py3-none-any.whl", hash = "sha256:6de9ce507115cff0bed95ff0ce9ecc31088ef50cbdf09bc90a09349a318b3d00", size = 13475, upload-time = "2024-08-30T05:31:48.659Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add datasette-updated plugin to display "last updated" timestamps in the Datasette footer
- Configure plugin with date format (e.g., "Dec 11, 2024")
- Add custom `_footer.html` template for full control over footer styling

## Changes
- `pyproject.toml`: Added `datasette-updated>=0.2.0` dependency
- `templates/config/metadata.json`: Added plugin config with `time_type: date`
- `templates/datasette/_footer.html`: New custom footer template including update timestamp

## Result
The "last updated" timestamp now appears in:
1. The description text (existing behavior)
2. The page footer (new - "Updated: Dec 11, 2024")

## Test plan
- [x] All 203 tests pass
- [x] Linting passes
- [ ] Manual verification: visit a subdomain site and confirm footer shows "Updated: <date>"

Closes #3