### PR TITLE
security: run Docker containers as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,11 +36,17 @@ FROM builder AS release
 ARG RELEASE_SHA=development
 RUN echo "${RELEASE_SHA}" > /.release
 
+# Create non-root user for security
+RUN useradd --no-create-home --no-log-init --shell /usr/sbin/nologin --uid 1000 appuser
+
 WORKDIR /app
 
 COPY . /app/
 
 ENV DJP_PLUGINS_DIR=django_plugins
+
+# Switch to non-root user
+USER appuser
 
 EXPOSE 8000
 

--- a/Dockerfile.sites
+++ b/Dockerfile.sites
@@ -39,8 +39,14 @@ RUN --mount=type=cache,target=/root/.cache,sharing=locked,id=pip \
 
 FROM builder AS release
 
+# Create non-root user for security
+RUN useradd --no-create-home --no-log-init --shell /usr/sbin/nologin --uid 1000 appuser
+
 WORKDIR /app
 
 COPY . /app/
+
+# Switch to non-root user
+USER appuser
 
 EXPOSE 8001


### PR DESCRIPTION
## Summary
- Add non-root `appuser` (UID 1000) to both Dockerfiles
- Containers now run as unprivileged user instead of root

## Security Hardening
- `--no-create-home`: No home directory (reduces attack surface)
- `--no-log-init`: Avoids large lastlog/faillog entries
- `--shell /usr/sbin/nologin`: Prevents shell access if exploited

## Test Plan
- [x] Both images build successfully
- [x] `docker run --rm <image> whoami` returns `appuser`
- [x] User has `/usr/sbin/nologin` shell in `/etc/passwd`
- [ ] Deploy and verify services start correctly