### PR TITLE
Remove standalone Datasette deployment from workflow

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -46,27 +46,11 @@ jobs:
             CANARY_PERIOD=$CANARY_PERIOD /home/deploy/scripts/deploy.sh corkboard-django ${{ github.sha }}
           "
 
-      - name: Build and deploy Datasette on VPS
-        env:
-          CANARY_PERIOD: ${{ inputs.canary_period || '120' }}
-        run: |
-          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-            deploy@${{ env.VPS_HOSTNAME }} "
-            cd /home/deploy/corkboard &&
-            docker build --no-cache -f Dockerfile.sites -t corkboard-datasette:${{ github.sha }} . &&
-            CANARY_PERIOD=$CANARY_PERIOD /home/deploy/scripts/deploy.sh corkboard-datasette ${{ github.sha }}
-          "
-
       - name: Verify Django deployment
         run: |
           sleep 30
           ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
             deploy@${{ env.VPS_HOSTNAME }} "curl -f -s http://localhost:8000/health/ || curl -f -s http://localhost:8001/health/"
-
-      - name: Verify Datasette deployment
-        run: |
-          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-            deploy@${{ env.VPS_HOSTNAME }} "curl -f -s http://localhost:40001/-/versions.json || curl -f -s http://localhost:40002/-/versions.json"
 
       - name: Notify Slack on failure
         if: failure()


### PR DESCRIPTION
## Summary
Removes the standalone Datasette deployment steps from the GitHub Actions workflow since all Datasette functionality is now served through the Django app.

## Background
All database access now goes through the Django app with the `datasette_by_subdomain` ASGI middleware (in `django_plugins/datasette_by_subdomain.py`). This creates Datasette instances on-demand for each subdomain, eliminating the need for separate Datasette service containers.

The docker-compose `sites_datasette_blue` and `sites_datasette_green` services were already removed in a previous commit, but the workflow was still trying to deploy them, causing deployment failures.

## Changes
- Remove "Build and deploy Datasette on VPS" step
- Remove "Verify Datasette deployment" step

## Fixes
This resolves the deployment failures that were looking for the non-existent `sites_datasette_green` service.