### PR TITLE
Fix: Use uv.lock in Docker builds for consistent dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,16 +15,15 @@ RUN apt-get update && \
     rm -rf /var/lib/apt && \
     rm -rf /var/lib/dpkg/info/*
 
-COPY pyproject.toml /tmp/pyproject.toml
+COPY pyproject.toml uv.lock /tmp/
 
 RUN --mount=type=cache,target=/root/.cache,sharing=locked,id=pip \
     python -m pip install --upgrade pip uv
 
 RUN --mount=type=cache,target=/root/.cache,sharing=locked,id=pip \
-    python -m uv pip compile /tmp/pyproject.toml -o /tmp/requirements.txt
-
-RUN --mount=type=cache,target=/root/.cache,sharing=locked,id=pip \
-    python -m uv pip install --system --requirement /tmp/requirements.txt
+    cd /tmp && \
+    python -m uv export --no-hashes --format requirements-txt -o requirements.txt && \
+    python -m uv pip install --system -r requirements.txt
 
 # ------------------------------------------------------------
 # Release layer

--- a/Dockerfile.sites
+++ b/Dockerfile.sites
@@ -16,16 +16,15 @@ RUN apt-get update && \
     rm -rf /var/lib/apt && \
     rm -rf /var/lib/dpkg/info/*
 
-COPY pyproject.toml /tmp/pyproject.toml
+COPY pyproject.toml uv.lock /tmp/
 
 RUN --mount=type=cache,target=/root/.cache,sharing=locked,id=pip \
     python -m pip install --upgrade pip uv
 
 RUN --mount=type=cache,target=/root/.cache,sharing=locked,id=pip \
-    python -m uv pip compile /tmp/pyproject.toml -o /tmp/requirements.txt
-
-RUN --mount=type=cache,target=/root/.cache,sharing=locked,id=pip \
-    python -m uv pip install --system --requirement /tmp/requirements.txt
+    cd /tmp && \
+    python -m uv export --no-hashes --format requirements-txt -o requirements.txt && \
+    python -m uv pip install --system -r requirements.txt
 
 # Install additional datasette plugins not in pyproject.toml
 RUN --mount=type=cache,target=/root/.cache,sharing=locked,id=pip \


### PR DESCRIPTION
## Summary
Fixes the `permission_allowed` error in production by ensuring Docker builds use the exact dependency versions from `uv.lock`.

## Root Cause
The Dockerfiles were using `uv pip compile` to generate requirements.txt at build time, which performed fresh dependency resolution instead of using the locked versions. This caused production to install Datasette 1.0a19 instead of the required 1.0a23, resulting in the `'Datasette' object has no attribute 'permission_allowed'` error.

## Changes
- Copy both `pyproject.toml` AND `uv.lock` to Docker build context
- Use `uv export` to convert `uv.lock` to requirements.txt format
- Install from the exported requirements.txt

## Impact
This ensures Docker builds use the exact same dependency versions that are locked in uv.lock:
- ✅ Datasette 1.0a23 (not 1.0a19)
- ✅ datasette-search-all 1.1.5a0 (not 1.1.4)
- ✅ All other dependencies match uv.lock exactly

## Testing
After deployment, verify:
```bash
curl https://alameda.ca.civic.band/-/versions.json | jq '.datasette.version'
# Should return: "1.0a23"
```