### PR TITLE
Add LICENSE file to Docker build context for uv export

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt && \
     rm -rf /var/lib/dpkg/info/*
 
-COPY pyproject.toml uv.lock /tmp/
+COPY pyproject.toml uv.lock LICENSE /tmp/
 
 RUN --mount=type=cache,target=/root/.cache,sharing=locked,id=pip \
     python -m pip install --upgrade pip uv

--- a/Dockerfile.sites
+++ b/Dockerfile.sites
@@ -16,7 +16,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt && \
     rm -rf /var/lib/dpkg/info/*
 
-COPY pyproject.toml uv.lock /tmp/
+COPY pyproject.toml uv.lock LICENSE /tmp/
 
 RUN --mount=type=cache,target=/root/.cache,sharing=locked,id=pip \
     python -m pip install --upgrade pip uv


### PR DESCRIPTION
## Summary
Fixes the Docker build failure: `OSError: License file does not exist: LICENSE`

## Root Cause
PR #45 changed the Dockerfiles to use `uv export` which converts `uv.lock` to requirements.txt format. However, `uv export` needs to build the `corkboard` package (since it's in the dependency tree), and the package build requires the LICENSE file that's referenced in `pyproject.toml`.

## Changes
- Add LICENSE to the COPY command in both Dockerfile and Dockerfile.sites
- Before: `COPY pyproject.toml uv.lock /tmp/`
- After: `COPY pyproject.toml uv.lock LICENSE /tmp/`

## Impact
This allows the Docker build to complete successfully with the locked dependency versions from `uv.lock`, ensuring Datasette 1.0a23 is installed in production.