### PR TITLE
Fix Docker build: use --no-emit-project instead of --no-editable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,14 +15,14 @@ RUN apt-get update && \
     rm -rf /var/lib/apt && \
     rm -rf /var/lib/dpkg/info/*
 
-COPY uv.lock /tmp/
+COPY pyproject.toml uv.lock /tmp/
 
 RUN --mount=type=cache,target=/root/.cache,sharing=locked,id=pip \
     python -m pip install --upgrade pip uv
 
 RUN --mount=type=cache,target=/root/.cache,sharing=locked,id=pip \
     cd /tmp && \
-    python -m uv export --no-hashes --no-editable --format requirements-txt -o requirements.txt && \
+    python -m uv export --no-hashes --no-emit-project --format requirements-txt -o requirements.txt && \
     python -m uv pip install --system -r requirements.txt
 
 # ------------------------------------------------------------

--- a/Dockerfile.sites
+++ b/Dockerfile.sites
@@ -16,14 +16,14 @@ RUN apt-get update && \
     rm -rf /var/lib/apt && \
     rm -rf /var/lib/dpkg/info/*
 
-COPY uv.lock /tmp/
+COPY pyproject.toml uv.lock /tmp/
 
 RUN --mount=type=cache,target=/root/.cache,sharing=locked,id=pip \
     python -m pip install --upgrade pip uv
 
 RUN --mount=type=cache,target=/root/.cache,sharing=locked,id=pip \
     cd /tmp && \
-    python -m uv export --no-hashes --no-editable --format requirements-txt -o requirements.txt && \
+    python -m uv export --no-hashes --no-emit-project --format requirements-txt -o requirements.txt && \
     python -m uv pip install --system -r requirements.txt
 
 # Install additional datasette plugins not in pyproject.toml


### PR DESCRIPTION
## Summary

Fixes the Docker build by using the correct `--no-emit-project` flag instead of `--no-editable` in the `uv export` command.

## Problem

The previous approach used `--no-editable` which doesn't exclude the project - it just converts editable installs to non-editable. This caused the build to fail because:
1. It tried to build the corkboard package
2. Building the package required LICENSE and README.md files
3. Even with those files, building the package is unnecessary

## Solution

Use `--no-emit-project` flag which completely excludes the corkboard project from the export, only including its dependencies. This is the correct approach for Docker builds where:
- We only need to install dependencies in the builder layer
- The full application code is copied separately in the release layer

Also added `pyproject.toml` to the COPY command since `uv export` needs it to read the project configuration.

## Testing

Tested locally with:
```bash
docker build -t corkboard-test:local .
```

Build succeeds and installs Datasette 1.0a23 with all required dependencies.

## Fixes

Resolves the "'Datasette' object has no attribute 'permission_allowed'" error by ensuring Datasette 1.0a23 (or later) is installed in production.