### PR TITLE
Add permission_allowed compatibility shim for datasette-dashboards

### DIFF
--- a/django_plugins/datasette_by_subdomain.py
+++ b/django_plugins/datasette_by_subdomain.py
@@ -315,7 +315,7 @@ async def datasette_by_subdomain_wrapper(scope, receive, send, app):
 
         from datasette.app import Datasette  # noqa: PLC0415
 
-        ds = Datasette(
+        datasette_instance = Datasette(
             db_list,
             config=metadata,
             plugins_dir="plugins",
@@ -330,7 +330,25 @@ async def datasette_by_subdomain_wrapper(scope, receive, send, app):
                 "allow_download": False,
                 "allow_csv_stream": False,
             },
-        ).app()
+        )
+
+        # Compatibility shim for datasette-dashboards 0.8.0 with Datasette 1.0+
+        # datasette-dashboards uses the deprecated permission_allowed() method
+        # that was removed in Datasette 1.0a20. Add it back as a wrapper.
+        async def permission_allowed(actor, action, resource=None, default=False):
+            """Compatibility wrapper for the old permission_allowed() API."""
+            result = await datasette_instance.allowed(
+                actor, action, resource, default=default
+            )
+            # allowed() returns True/False, permission_allowed() returned True/False/None
+            # If default=None, we should return None when permission is denied
+            if default is None and not result:
+                return None
+            return result
+
+        datasette_instance.permission_allowed = permission_allowed
+
+        ds = datasette_instance.app()
 
         # Import NotFound to catch 404s before they hit Datasette's
         # exception handler (which calls rich.print_exception and fails)


### PR DESCRIPTION
## Summary

Fixes the `'Datasette' object has no attribute 'permission_allowed'` error by adding a compatibility shim for datasette-dashboards 0.8.0.

## Problem

datasette-dashboards 0.8.0 (latest on PyPI) uses the deprecated `permission_allowed()` method that was removed in Datasette 1.0a20. The new Datasette 1.0 uses `allowed()` instead, as part of the new SQL-powered permissions system.

## Root Cause

We upgraded to Datasette 1.0a23 in PR #43, but datasette-dashboards hasn't been updated for Datasette 1.0 compatibility yet. The plugin directly calls:
```python
await datasette.permission_allowed(
    request.actor,
    "view-instance",
    default=None,
)
```

This method no longer exists in Datasette 1.0+.

## Solution

Added a compatibility shim that:
1. Wraps the new `allowed()` API with the old `permission_allowed()` signature
2. Is attached to each Datasette instance created in the subdomain middleware
3. Handles the semantic differences between the old and new APIs

The shim is added in `datasette_by_subdomain.py` right after the Datasette instance is created, before `.app()` is called.

## Testing

- Local testing: Server starts without errors
- Production testing needed: The subdomain routing doesn't work on localhost

## Future Work

This shim can be removed once datasette-dashboards is updated to support Datasette 1.0's new permission system. Track upstream progress at:
- https://github.com/rclement/datasette-dashboards/issues

## Fixes

Resolves the `'Datasette' object has no attribute 'permission_allowed'` error when accessing dashboard pages like `https://alameda.ca.civic.band/-/dashboards/meetings-stats`