### PR TITLE
Fix allowed() API call - use correct parameter names

### DIFF
--- a/django_plugins/datasette_by_subdomain.py
+++ b/django_plugins/datasette_by_subdomain.py
@@ -337,8 +337,10 @@ async def datasette_by_subdomain_wrapper(scope, receive, send, app):
         # that was removed in Datasette 1.0a20. Add it back as a wrapper.
         async def permission_allowed(actor, action, resource=None, default=False):
             """Compatibility wrapper for the old permission_allowed() API."""
+            # New API: allowed(action, resource=None, actor=None)
+            # Old API: permission_allowed(actor, action, resource=None, default=False)
             result = await datasette_instance.allowed(
-                actor, action, resource, default=default
+                action=action, resource=resource, actor=actor
             )
             # allowed() returns True/False, permission_allowed() returned True/False/None
             # If default=None, we should return None when permission is denied


### PR DESCRIPTION
## Summary

Fixes the `Datasette.allowed() got an unexpected keyword argument 'default'` error in the permission_allowed compatibility shim.

## Problem

PR #50 added a compatibility shim for datasette-dashboards, but the implementation was calling `allowed()` with incorrect parameters:
```python
result = await datasette_instance.allowed(
    actor, action, resource, default=default  # ❌ Wrong!
)
```

The Datasette 1.0 `allowed()` method signature is:
```python
allowed(action, resource=None, actor=None)  # ✅ Correct
```

It doesn't accept a `default` parameter and has a different parameter order.

## Solution

Fixed the shim to use keyword arguments with the correct parameter names:
```python
result = await datasette_instance.allowed(
    action=action, resource=resource, actor=actor
)
```

## Testing

This needs to be tested in production on the subdomain dashboards (localhost bypasses subdomain routing).

Test URL: https://alameda.ca.civic.band/-/dashboards/meetings-stats

## Fixes

Resolves: `Datasette.allowed() got an unexpected keyword argument 'default'` error