### PR TITLE
Convert Database objects to DatabaseResource for allowed() API

### DIFF
--- a/django_plugins/datasette_by_subdomain.py
+++ b/django_plugins/datasette_by_subdomain.py
@@ -337,8 +337,16 @@ async def datasette_by_subdomain_wrapper(scope, receive, send, app):
         # that was removed in Datasette 1.0a20. Add it back as a wrapper.
         async def permission_allowed(actor, action, resource=None, default=False):
             """Compatibility wrapper for the old permission_allowed() API."""
+            from datasette.database import Database  # noqa: PLC0415
+            from datasette.resources import DatabaseResource  # noqa: PLC0415
+
             # New API: allowed(action, resource=None, actor=None)
             # Old API: permission_allowed(actor, action, resource=None, default=False)
+
+            # Convert Database objects to DatabaseResource objects
+            if isinstance(resource, Database):
+                resource = DatabaseResource(database=resource.name)
+
             result = await datasette_instance.allowed(
                 action=action, resource=resource, actor=actor
             )


### PR DESCRIPTION
## Summary

Fixes the `'str' object has no attribute 'parent'` error by converting Database objects to DatabaseResource objects in the permission_allowed compatibility shim.

## Problem

The Datasette 1.0 `allowed()` API expects Resource objects (DatabaseResource, TableResource, etc.), not the old Database/Table objects.

datasette-dashboards 0.8.0 passes Database objects directly:
```python
await datasette.permission_allowed(
    request.actor,
    "execute-sql",
    resource=database,  # ❌ Database object, not DatabaseResource
    default=None,
)
```

When our shim passes this Database object to `allowed()`, it fails because `allowed()` expects a DatabaseResource object with a specific structure.

## Solution

The compatibility shim now detects Database objects and converts them:
```python
from datasette.database import Database
from datasette.resources import DatabaseResource

if isinstance(resource, Database):
    resource = DatabaseResource(database=resource.name)
```

## Testing

Needs testing on: https://alameda.ca.civic.band/-/dashboards/meetings-stats

## Fixes

Resolves: `'str' object has no attribute 'parent'` error when accessing dashboard pages