### PR TITLE
Fix docker-compose to pull from GitHub Container Registry

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - "./botPolicy.yaml:/data/cfg/botPolicy.yaml:ro"
   django_blue:
-    image: corkboard-django:${VERSION:-latest}
+    image: ghcr.io/civicband/corkboard:${VERSION:-latest}
     # Code is baked into the image - no local build or volume mount
     volumes:
       # Only mount data, not code
@@ -44,7 +44,7 @@ services:
     volumes:
       - "./botPolicy.yaml:/data/cfg/botPolicy.yaml:ro"
   django_green:
-    image: corkboard-django:${VERSION:-latest}
+    image: ghcr.io/civicband/corkboard:${VERSION:-latest}
     # Code is baked into the image - no local build or volume mount
     volumes:
       # Only mount data, not code


### PR DESCRIPTION
## Problem

The docker-compose.yml was configured to use a local image tag `corkboard-django:latest`, but the GitHub Actions CI workflow pushes images to `ghcr.io/civicband/corkboard:latest`. This meant that deployments weren't picking up the latest built images from CI, causing issues like missing dependencies (e.g., social-auth-app-django from PR #55).

## Solution

Update the image references in docker-compose.yml to pull from GitHub Container Registry:

**Before:**
```yaml
image: corkboard-django:${VERSION:-latest}
```

**After:**
```yaml
image: ghcr.io/civicband/corkboard:${VERSION:-latest}
```

## Changes

- Updated `django_blue` service to use `ghcr.io/civicband/corkboard:${VERSION:-latest}`
- Updated `django_green` service to use `ghcr.io/civicband/corkboard:${VERSION:-latest}`

## Benefits

- Deployments now automatically use the latest CI-built images
- No need for manual local image builds
- Ensures consistency between CI and production environments
- Fixes the missing OIDC endpoints issue (social-auth-app-django wasn't in old images)

## Deployment

After merging, pull the new image and restart services:

```bash
docker-compose pull
docker-compose up -d --force-recreate
```

Or if you need to authenticate with ghcr.io first:

```bash
echo $GITHUB_TOKEN | docker login ghcr.io -u USERNAME --password-stdin
docker-compose pull
docker-compose up -d --force-recreate
```

Note: The images are public, so authentication shouldn't be required for pulling.