### PR TITLE
Fix prod_settings to respect DATABASE_URL

### DIFF
--- a/config/prod_settings.py
+++ b/config/prod_settings.py
@@ -2,13 +2,5 @@ from config.settings import *
 
 DEBUG = False
 
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "sites.db",
-    },
-    "sites": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "sites.db",
-    },
-}
+# DATABASES is already configured in config.settings with DATABASE_URL support
+# Don't override it here - let the base settings handle Postgres vs SQLite fallback


### PR DESCRIPTION
## Problem

The `config/prod_settings.py` file was hardcoding the `DATABASES` setting to use SQLite:

```python
DATABASES = {
    "default": {
        "ENGINE": "django.db.backends.sqlite3",
        "NAME": BASE_DIR / "sites.db",
    },
}
```

This overrode the DATABASE_URL logic from `config/settings.py`, which means even when `DATABASE_URL` was set to a Postgres connection string, production deployments were still trying to use SQLite.

This caused the error:
```
sqlite3.OperationalError: no such table: sites
```

## Solution

Remove the `DATABASES` override from `prod_settings.py` and let the base settings handle database configuration. The base settings already have proper logic:

- If `DATABASE_URL` is set → use Postgres (parsed via dj-database-url)
- If `DATABASE_URL` is not set → fallback to SQLite for local development

## Impact

- Production deployments will now correctly use the Postgres database when `DATABASE_URL` is set
- The `sites` table will be accessible (it exists in the clerk Postgres database)
- OIDC endpoints and other functionality will work properly
- No impact on local development (DATABASE_URL not set → SQLite fallback still works)

## Testing

After merge and deployment with DATABASE_URL set:
- Homepage should load without "no such table: sites" errors
- `/login/oidc/` endpoint should be accessible
- Admin interface should work