### PR TITLE
Fix HTTPS detection for OIDC redirect URIs

### DIFF
--- a/config/prod_settings.py
+++ b/config/prod_settings.py
@@ -4,3 +4,9 @@ DEBUG = False
 
 # DATABASES is already configured in config.settings with DATABASE_URL support
 # Don't override it here - let the base settings handle Postgres vs SQLite fallback
+
+# Trust proxy headers for HTTPS detection
+# This ensures redirect URIs use https:// instead of http://
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+USE_X_FORWARDED_HOST = True
+USE_X_FORWARDED_PORT = True


### PR DESCRIPTION
## Problem

When initiating OIDC login at `/login/oidc/`, the redirect_uri being sent to the identity provider was using HTTP instead of HTTPS:

```
redirect_uri=http://civic.band/complete/oidc/
```

This caused an "invalid callback URL" error because the registered redirect URI is:
```
https://civic.band/complete/oidc/
```

Django was generating `http://` URLs because it didn't know it was behind a reverse proxy/load balancer that terminates SSL.

## Solution

Add proxy header trust settings to `prod_settings.py`:

```python
SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
USE_X_FORWARDED_HOST = True
USE_X_FORWARDED_PORT = True
```

These settings tell Django to:
- Trust the `X-Forwarded-Proto` header to detect HTTPS
- Trust the `X-Forwarded-Host` header for the hostname
- Trust the `X-Forwarded-Port` header for the port

## Impact

- OIDC redirect URIs will now correctly use `https://civic.band/complete/oidc/`
- Matches the URL registered in the OIDC provider
- OIDC login flow will complete successfully
- Other Django features that generate absolute URLs will also use HTTPS correctly

## Testing

After deployment, accessing `/login/oidc/` should redirect to the OIDC provider with:
```
redirect_uri=https://civic.band/complete/oidc/
```

And the callback should complete successfully.