### PR TITLE
Make worker recycling more aggressive to reduce memory leak

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,4 +57,4 @@ USER appuser
 EXPOSE 8000
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["gunicorn", "config.asgi:application", "-k", "uvicorn.workers.UvicornWorker", "--bind", "0.0.0.0:8000", "--max-requests", "1000", "--max-requests-jitter", "100", "--timeout", "30", "--graceful-timeout", "7"]
+CMD ["gunicorn", "config.asgi:application", "-k", "uvicorn.workers.UvicornWorker", "--bind", "0.0.0.0:8000", "--max-requests", "200", "--max-requests-jitter", "50", "--timeout", "30", "--graceful-timeout", "10", "--worker-tmp-dir", "/dev/shm"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - DJP_PLUGINS_DIR=django_plugins
       - WEB_CONCURRENCY=4
       - REDIS_URL=redis://redis:6379
-    command: gunicorn config.asgi:application -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000 --max-requests 1000 --max-requests-jitter 100 --timeout 30 --graceful-timeout 7
+    command: gunicorn config.asgi:application -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000 --max-requests 200 --max-requests-jitter 50 --timeout 30 --graceful-timeout 10 --worker-tmp-dir /dev/shm
     ports:
       - 9000:8000
     depends_on:
@@ -58,7 +58,7 @@ services:
       - DJP_PLUGINS_DIR=django_plugins
       - WEB_CONCURRENCY=4
       - REDIS_URL=redis://redis:6379
-    command: gunicorn config.asgi:application -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000 --max-requests 1000 --max-requests-jitter 100 --timeout 30 --graceful-timeout 7
+    command: gunicorn config.asgi:application -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000 --max-requests 200 --max-requests-jitter 50 --timeout 30 --graceful-timeout 10 --worker-tmp-dir /dev/shm
     ports:
       - 9001:8000
     depends_on:


### PR DESCRIPTION
## Summary

Makes worker recycling 5x more aggressive to further reduce memory leak impact observed in production after the initial Gunicorn migration (PR #62).

## Problem

After switching from uvicorn to Gunicorn + UvicornWorker in PR #62, the memory leak is **better but still present**. Workers recycling every ~1000 requests isn't frequent enough to prevent noticeable memory accumulation.

## Solution

Make worker recycling much more aggressive:

- **Reduce `--max-requests` from 1000 to 200** (5x more frequent recycling)
- **Reduce `--max-requests-jitter` from 100 to 50** (workers restart between 150-250 requests)
- **Add `--worker-tmp-dir /dev/shm`** for tmpfs-based heartbeat files (better performance)
- **Increase `--graceful-timeout` to 10s** (was 7s) to allow more time for cleanup

## Changes

- Modified Dockerfile CMD with more aggressive settings
- Updated both blue and green deployment commands in docker-compose.yml

## Impact

- Workers will restart every ~200 requests instead of ~1000
- Memory will have less time to accumulate before recycling
- Slight increase in restart overhead, but negligible compared to memory leak impact
- Using /dev/shm reduces disk I/O for gunicorn's worker heartbeat mechanism

## Testing

After deployment, monitor for:
- Reduced maximum memory usage per worker
- More frequent sawtooth pattern (tighter oscillation)
- Overall lower steady-state memory consumption
- No impact on request handling or error rates