### PR TITLE
Fix quick links grid layout for 5 buttons

### DIFF
--- a/templates/datasette/index.html
+++ b/templates/datasette/index.html
@@ -318,7 +318,7 @@
 
 @media (min-width: 480px) {
     .quick-links {
-        grid-template-columns: repeat(4, 1fr);
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
     }
 }
 


### PR DESCRIPTION
## Problem

After merging PR #68 which added the conditional Campaign Finance button, the quick links section can have 5 buttons when a site has finance data. The current fixed 4-column grid causes the 5th button to wrap awkwardly to a new line by itself.

## Solution

Changed the grid layout from fixed  to responsive .

## Result

The grid now automatically adapts:
- **4 buttons**: Displays nicely in a single row (Statistics, Upcoming, Agendas, Minutes)
- **5 buttons**: Displays nicely in a single row (adds Campaign Finance)
- **Responsive**: Maintains clean 2-column layout on mobile

## Changes

- Updated  grid template columns in 
- Single line change, no functional impact
- Purely visual/layout improvement

## Testing

- Tested with 4 buttons (sites without finance data)
- Tested with 5 buttons (sites with finance data)
- Verified responsive behavior on mobile

## Screenshots

### Before
- 4 buttons: ✅ OK
- 5 buttons: ❌ 5th button wraps awkwardly alone on second row

### After  
- 4 buttons: ✅ Perfect
- 5 buttons: ✅ All 5 fit nicely in one row