### PR TITLE
Update SECURE_REFERRER_POLICY to strict-origin-when-cross-origin

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -188,6 +188,14 @@ SOCIAL_AUTH_PIPELINE = (
     "social_core.pipeline.user.user_details",
 )
 
+# Django's SecurityMiddleware defaults to "same-origin", which prevents the browser from sending
+# the Referer header on cross-origin requests, e.g. to tile.openstreetmap.org.
+# "strict-origin-when-cross-origin" sends the origin (i.e. up to, and including the tld) as the
+# referer on cross-origin requests.
+# refs:
+#       - https://docs.djangoproject.com/en/5.2/ref/middleware/#referrer-policy
+#       - https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Referrer-Policy
+SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
 
 # Internationalization
 # https://docs.djangoproject.com/en/5.0/topics/i18n/


### PR DESCRIPTION
We had to do [the same](https://github.com/DemocracyClub/UK-Polling-Stations/pull/9158/changes/69aee37fe52aac9c616946c927a43b44c2cf34b7) for our sites to deal with the 403 warning tiles from OSM. 
I haven't checked out the code or tried it locally, so I don't know that this fix has worked, but think it probably will. 